### PR TITLE
Update prices.yaml

### DIFF
--- a/.spice/datasets/prices.yaml
+++ b/.spice/datasets/prices.yaml
@@ -28,8 +28,8 @@ migrations:
               price,
               pair
               from spiceai.datasets.trades
-          ) 
-        )
+          ) as base_trades
+        ) as aggregated_trades
         GROUP BY pair, timestamp_minute
         ORDER BY pair, "timestamp" DESC
       )


### PR DESCRIPTION
Even though the original SELECT query is valid (even in the SpiceAI playground), it fails when used within the create view datasets YAML
```
failed to deploy
subquery in FROM must have an alias
```
Appears to be a discrepancy between our SQL parsing on Cloud and what's valid on data-platform.