### PR TITLE
Update eigenlayer_eigenpod_validators.yml

### DIFF
--- a/.spice/datasets/eigenlayer_eigenpod_validators.yml
+++ b/.spice/datasets/eigenlayer_eigenpod_validators.yml
@@ -7,6 +7,6 @@ migrations:
         SELECT *
         FROM eth.beacon.validators val 
         WHERE val.withdrawal_credentials IN (
-          select withdrawal_credential from eth.eigenlayer.eigenpods
+          select withdrawal_credential from spiceai.datasets.internal_eigenlayer_eigenpods
         )
       )


### PR DESCRIPTION
`spiceai` org doesn't have access to `eth.eigenlayer.*` (it did in dev, somehow). This view depended on the public view, now it will depend on the internally created view.